### PR TITLE
fix: [PAYMCLOUD-302] Refactor dynamic subscription ID handling for azurerm providers

### DIFF
--- a/azure-devops/iacv2-projects/00_secrets_prod.tf
+++ b/azure-devops/iacv2-projects/00_secrets_prod.tf
@@ -12,9 +12,5 @@ module "secrets" {
     "cstar-azure-devops-github-ro-TOKEN",
     "cstar-azure-devops-github-rw-TOKEN",
     "cstar-azure-devops-github-pr-TOKEN",
-    "TENANT-ID",
-    "DEV-SUBSCRIPTION-ID",
-    "UAT-SUBSCRIPTION-ID",
-    "PROD-SUBSCRIPTION-ID",
   ]
 }

--- a/azure-devops/iacv2-projects/99_main.tf
+++ b/azure-devops/iacv2-projects/99_main.tf
@@ -29,19 +29,19 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   alias           = "dev"
-  subscription_id = module.secrets.values["DEV-SUBSCRIPTION-ID"].value
+  subscription_id = data.azurerm_subscriptions.dev.subscriptions[0].subscription_id
 }
 
 provider "azurerm" {
   features {}
   alias           = "uat"
-  subscription_id = module.secrets.values["UAT-SUBSCRIPTION-ID"].value
+  subscription_id = data.azurerm_subscriptions.uat.subscriptions[0].subscription_id
 }
 
 provider "azurerm" {
   features {}
   alias           = "prod"
-  subscription_id = module.secrets.values["PROD-SUBSCRIPTION-ID"].value
+  subscription_id = data.azurerm_subscriptions.prod.subscriptions[0].subscription_id
 }
 
 module "__v3__" {


### PR DESCRIPTION
### List of changes

- Replaced hardcoded subscription IDs in secrets with dynamic lookups using `data.azurerm_subscriptions`.

### Motivation and context

This change improves maintainability by removing hardcoded subscription IDs and automating their retrieval. It eliminates the need for manual updates, reducing the chances of errors and ensuring up-to-date configuration.

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

No further information is required as the change focuses on improving the subscription ID configuration process.