### PR TITLE
feat: [IDP-2786] Add "pagopa.it" domain to TLS configuration

### DIFF
--- a/azure-devops/idpay-itn-projects/10_tls_certs_bonus_elettrodomestici.tf
+++ b/azure-devops/idpay-itn-projects/10_tls_certs_bonus_elettrodomestici.tf
@@ -1,6 +1,6 @@
 locals {
   # Domains and environment configs
-  bonus_elettrodomestici_domains   = ["it", "com", "info", "io", "net", "eu"]
+  bonus_elettrodomestici_domains   = ["it", "com", "info", "io", "net", "eu", "pagopa.it"]
   environments                     = ["dev", "uat", "prod"]
   key_vault_service_connection_key = "KEY_VAULT_SERVICE_CONNECTION"
 


### PR DESCRIPTION
### List of changes

- Added "pagopa.it" to the `bonus_elettrodomestici_domains` in the TLS certificates configuration.

### Motivation and context

The change is required to include the "pagopa.it" domain in the TLS setup, ensuring proper certificate handling and compatibility.

### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

No additional information.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A