### PR TITLE
chore: MMC-806 Fix github bot with permission on private repository

### DIFF
--- a/azure-devops/mdc-itn-projects/30_pipeline_emd_ar_backoffice_admin_fe.tf
+++ b/azure-devops/mdc-itn-projects/30_pipeline_emd_ar_backoffice_admin_fe.tf
@@ -47,9 +47,9 @@ module "emd_ar_backoffice_admin_fe_deploy" {
 
   project_id                   = local.devops_project_id
   repository                   = var.emd_ar_backoffice_admin_fe.repository
-  github_service_connection_id = azuredevops_serviceendpoint_github.bot_github_pr.id
+  github_service_connection_id = azuredevops_serviceendpoint_github.bot_github_rw.id
 
-  pipeline_name         = "emd_ar_backoffice_admin_fe.deploy"
+  pipeline_name         = "emd-ar-backoffice-admin-fe.deploy"
   pipeline_yml_filename = "deploy-pipelines.yml"
   path                  = var.emd_ar_backoffice_admin_fe.pipeline.path
 
@@ -61,7 +61,7 @@ module "emd_ar_backoffice_admin_fe_deploy" {
   variables_secret = {}
 
   service_connection_ids_authorization = [
-    azuredevops_serviceendpoint_github.bot_github_pr.id,
+    azuredevops_serviceendpoint_github.bot_github_rw.id,
     local.dev_service_endpoint_azure_id,
     local.uat_service_endpoint_azure_id,
     local.prod_service_endpoint_azure_id


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- changed name of pipeline
- changed github bot with bot_github_rw that have permission on private repository

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
